### PR TITLE
Remove asterisks from CPF/CNPJ labels in boleto and cc payment templates

### DIFF
--- a/view/frontend/web/template/payment/boleto.html
+++ b/view/frontend/web/template/payment/boleto.html
@@ -40,7 +40,7 @@
 
         <div class="field document required">
             <label data-bind="attr: {for: getCode() + '_boletodocument'}" class="label">
-                <span><!-- ko i18n: 'CPF/CNPJ'--><!-- /ko --> <span class="required">*</span></span>
+                <span><!-- ko i18n: 'CPF/CNPJ'--><!-- /ko --></span>
             </label>
             <div class="control">
                 <input type="text" name="boletodocument" class="input-text" style="max-width:300px;!important"

--- a/view/frontend/web/template/payment/cc.html
+++ b/view/frontend/web/template/payment/cc.html
@@ -72,7 +72,7 @@
                 </div>
                 <div class="field document required">
                     <label data-bind="attr: {for: getCode() + '_document'}" class="label">
-                        <span><!-- ko i18n: 'CPF'--><!-- /ko --> <span class="required">*</span>
+                        <span><!-- ko i18n: 'CPF'--><!-- /ko --></span>
                     </label>
                     <div class="control">
                         <input type="text" name="document" class="input-text" style="max-width: 300px;" value="" required


### PR DESCRIPTION
Remove asterisks from CPF/CNPJ labels in boleto and cc payment templates